### PR TITLE
Set default value for SEND_SUBMIT_EMAIL in oxford migration script

### DIFF
--- a/mneme/mneme-impl/impl/src/sql/mysql/mneme_assessment_oxford.sql
+++ b/mneme/mneme-impl/impl/src/sql/mysql/mneme_assessment_oxford.sql
@@ -2,4 +2,4 @@
 -- Mneme Assessment DDL changes from Oxford version
 -- ---------------------------------------------------------------------------
 
-ALTER TABLE MNEME_ASSESSMENT ADD (PASS_MARK FLOAT, SEND_SUBMIT_EMAIL CHAR (1));
+ALTER TABLE MNEME_ASSESSMENT ADD (PASS_MARK FLOAT, SEND_SUBMIT_EMAIL CHAR (1) DEFAULT 0);


### PR DESCRIPTION
Fixes #6 
Set default value for SEND_SUBMIT_EMAIL in oxford migration script. A value is required for migration of existing assessments.